### PR TITLE
NO-TICKET: Changed dependabot to monthly requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/packages/store"
     schedule:
-      interval: "daily"
-      time: "02:00"
+      interval: "monthly"
     commit-message:
       prefix: "misc"
     labels:


### PR DESCRIPTION
What this PR does / why we need it: In order to avoid dependabot spamming some of our mails, we decided to change its rythm to a monthly bump.

Which issue(s) this PR fixes:

- Fixes #

