### PR TITLE
NO-TICKET: accept React 16 as peer dep

### DIFF
--- a/packages/store-react/CHANGELOG.md
+++ b/packages/store-react/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add React 16 as a peerDependency accepted
+
 ## [1.1.2]
 
 -   Update dependencies

--- a/packages/store-react/package.json
+++ b/packages/store-react/package.json
@@ -56,6 +56,6 @@
   },
   "peerDependencies": {
     "@iadvize-oss/store": "*",
-    "react": "^17.0.2"
+    "react": "^16.14.0 || ^17.0.0"
   }
 }


### PR DESCRIPTION
What this PR does / why we need it:

Which issue(s) this PR fixes:

- Fixes #

